### PR TITLE
Enable universal wheel build

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
 [metadata]
 license-file = LICENSE
 description-file = README.rst
+
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
I noticed that footprints is using a local fork of edtf. When doing some initial python 3 testing on footprints, edtf is causing this failure:

>   reading manifest file 'edtf.egg-info/SOURCES.txt'
>   writing manifest file 'edtf.egg-info/SOURCES.txt'
>   Copying edtf.egg-info to build/bdist.linux-x86_64/wheel/edtf-0.9.2-py3.6.egg-info
>   running install_scripts
>   error: [Errno 2] No such file or directory: 'LICENSE'
> 
>   ----------------------------------------
>   Failed building wheel for edtf
>   Running setup.py clean for edtf

This change may fix that.