### PR TITLE
:bookmark: release version 0.9.4

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,9 @@
+0.9.4 (2024-08-27)
+=====================
+
+* Release new version 0.9.4 - newer versions of pip don't allow
+  letters in the version number.
+
 0.9.3ctl (2019-07-09)
 =====================
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ import setuptools
 
 setuptools.setup(
     name='edtf',
-    version='0.9.3ctl',
+    version='0.9.4',
     url='https://github.com/ixc/python-edtf',
     author='Greg Turner',
     author_email='greg@interaction.net.au',


### PR DESCRIPTION
There are no code changes here, but newer versions of pip don't allow letters in the version number, so I'll just use 0.9.4 as our custom vendored release of this old version of edtf for footprints.